### PR TITLE
Launch deploys correctly on force push (issue #5)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Check for charm/ changes
         id: check
         run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^charm/'; then
+          if git diff --name-only HEAD~ ${{ github.sha }} | grep '^charm/'; then
             echo "charm_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "charm_changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Copy-pasting #5 description below for convenience:

> https://github.com/canonical/webteam-devops/blob/641bb6f7def6afe5c99a401f9c4d3cac5cbb566f/.github/workflows/deploy.yaml#L50
> 
> Just ran into an edge case in using `github.event.before`: doing a force push overwrites the git history, making the `before` reference point to a bad object that isn't accessible; this blocks the charm from being redeployed, even when the charm file was changed.
> 
> The easiest way to fix this issue would be using `HEAD~` (a.k.a. the commit before the current HEAD): rather than control the commit that was pushed previously (which gets erased by forced pushes), we should control the previous commit according to Git history.
> 
> ```patch
> -           if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '^charm/'; then 
> +           if git diff --name-only HEAD~ ${{ github.sha }} | grep '^charm/'; then  
> ```

This change in action (I launched the action using the fixed branch and it correctly detects the charmcraft.yaml being changed):
https://github.com/canonical/snapcraft.io/actions/runs/16003919589/job/45145735988?pr=5181