### PR TITLE
fix: pin charmcraft snap channel to 3.x/stable

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -92,7 +92,7 @@ jobs:
         uses: canonical/setup-lxd@main
 
       - name: Setup charmcraft
-        run: sudo snap install charmcraft --classic --channel=latest/stable
+        run: sudo snap install charmcraft --classic --channel=3.x/stable
 
       - name: Fetch libs
         run: |


### PR DESCRIPTION
Pinned charmcraft snap version to 3.x. This avoids a known charmcraft 4.0 bug that breaks the upload command when running it outside of the charm project directory reporting `charmcraft internal error: RuntimeError('Project not configured yet.')`

evidence of the error:
- https://github.com/canonical/snapcraft.io/actions/runs/20857908233/job/59929533963
- https://github.com/canonical/charmhub.io/actions/runs/21665632530/job/62460281799

more info about the bug here: https://github.com/canonical/charmcraft/issues/2492