### PR TITLE
fix: use specific image ID instead of head -n 1

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -128,8 +128,13 @@ jobs:
       - name: Push to GHCR
         run: skopeo --insecure-policy copy oci-archive:$(ls *.rock) docker://${{ steps.set_image_url.outputs.image_url }} --dest-creds "canonical:${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Pull image into registry
-        run: docker pull ${{ steps.set_image_url.outputs.image_url }}
+      - name: Pull image and get ID
+        id: pull_image
+        run: |
+          docker pull ${{ steps.set_image_url.outputs.image_url }}
+          IMAGE_ID=$(docker images --format "{{.ID}}" ${{ steps.set_image_url.outputs.image_url }})
+          echo "image_id=$IMAGE_ID" >> $GITHUB_OUTPUT
+          echo "Pulled image ID: $IMAGE_ID"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -151,7 +156,7 @@ jobs:
       - name: Upload OCI image resource
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
-        run: charmcraft upload-resource ${{ inputs.charm_name }} ${{ steps.resource_name.outputs.resource_name }} --image=$(docker images --format "{{.ID}}" | head -n 1) --verbosity=trace
+        run: charmcraft upload-resource ${{ inputs.charm_name }} ${{ steps.resource_name.outputs.resource_name }} --image=${{ steps.pull_image.outputs.image_id }} --verbosity=trace
 
       - name: Attach resource to charm and release
         env:


### PR DESCRIPTION
 `docker images --format "{{.ID}}" | head -n 1` doesn't return the image we just pulled, it returns the first image sorted by creation time. This can result in uploading a wrong/cached image as the charm resource.