### PR TITLE
fix rock artifact name for custom app deployments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: Get Rock
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.charm_name }}-rock
+          name: ${{ inputs.app_name  || inputs.charm_name }}-rock
 
       - name: Set image URL
         id: set_image_url


### PR DESCRIPTION
## Issue
Currently, the `custom-app-name` workflow uploads the rock artifact using `app_name || charm_name`, but later tries to download it using only `charm_name`. For services where `app_name` and `charm_name` are different (`charmhub-solutions-app` vs `charmhub-solutions`), the [deployment fails](https://github.com/canonical/charmhub-solutions-service/actions/runs/26805472739/job/79024899523) with “Artifact not found”.

## Done
- Fixes staging deploy artifact lookup for custom app names - makes the download step use the same artifact name as the upload step